### PR TITLE
download, merge, summarize logs

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,3 +4,5 @@ pdf2image==1.16.*
 pandas==1.5.*
 google-cloud-storage==2.7.*
 google-cloud-logging==3.3.*
+pyarrow==11.*
+fastparquet==2023.1.0

--- a/row.py
+++ b/row.py
@@ -153,7 +153,7 @@ def get_files_from_index(from_location, task_index, task_count, total_size):
     return file_list
 
 
-def convert_pdf_to_jpg_bytes(pdf_as_bytes):
+def convert_pdf_to_jpg_bytes(pdf_as_bytes, object_name):
     """convert pdf to jpg images
 
     Args:
@@ -168,8 +168,8 @@ def convert_pdf_to_jpg_bytes(pdf_as_bytes):
 
     try:
         images = convert_from_bytes(pdf_as_bytes, dpi)
-        logging.error(error)
     except (TypeError, PDFInfoNotInstalledError, PDFPageCountError, PDFSyntaxError, DecompressionBombError) as error:
+        logging.error("error in %s, %s", object_name, error, exc_info=True)
         messages = error
 
     count = len(images)

--- a/row.py
+++ b/row.py
@@ -209,8 +209,6 @@ def get_circles_from_image_bytes(byte_img, output_path, file_name):
     #: to calculate circle radius, get input image size
     [height, width, _] = img.shape
 
-    logging.info("dimensions: %d x %d", height, width)
-
     #: original multiplier of 0.01, bigger seems to work better (0.025)
     multipliers = [
         [0.010, 12],
@@ -229,7 +227,6 @@ def get_circles_from_image_bytes(byte_img, output_path, file_name):
 
     while (circle_count > 100 or circle_count == 0) and count_down > 0:
         i += 1
-        logging.info("Run: %8d", i)
 
         [ratio_multiplier, fudge_value] = multipliers[count_down - 1]
 
@@ -262,11 +259,18 @@ def get_circles_from_image_bytes(byte_img, output_path, file_name):
         else:
             circle_count = len(detected_circles[0])
 
-        logging.info("Circles: %4i", circle_count)
-        logging.info("Multiplier: %5.4f", ratio_multiplier)
-        logging.info("Fudge: %7i", fudge_value)
-        logging.info("Diameter: %6d-%d", min_rad, max_rad)
-        logging.info("Inset: %6i", inset)
+        logging.info(
+            "Run: %i found %i circles %s",
+            i,
+            circle_count,
+            {
+                "multiplier": ratio_multiplier,
+                "fudge": fudge_value,
+                "diameter": f"{min_rad}-{max_rad}",
+                "inset": inset,
+                "dimensions": f"{height}x{width}",
+            },
+        )
 
         count_down -= 1
 

--- a/row.py
+++ b/row.py
@@ -414,8 +414,8 @@ def export_circles_from_image(circles, out_dir, file_name, cv2_image, height, wi
     return masked_images
 
 
-def write_results(frame, obj_name, results):
-    """write detected results to a dataframe by concatenating them onto the end of
+def append_results(frame, obj_name, results):
+    """append detected results to a dataframe by concatenating them onto the end of
         the existing dataframe
 
     Args:
@@ -432,13 +432,13 @@ def write_results(frame, obj_name, results):
     return frame
 
 
-def upload_csv(frame, bucket_name, out_name):
-    """upload results dataframe to a GCP bucket as a CSV file
+def upload_results(frame, bucket_name, out_name):
+    """upload results dataframe to a GCP bucket as a gzip file
 
     Args:
         frame (dataframe): dataframe containing the final results
         bucket_name (str): the name of the destination bucket
-        out_name (str): the name of the CSV file
+        out_name (str): the name of the gzip file
 
     Returns:
         nothing

--- a/row.py
+++ b/row.py
@@ -20,6 +20,7 @@ import pandas as pd
 import pytesseract
 from pdf2image import convert_from_bytes
 from pdf2image.exceptions import PDFInfoNotInstalledError, PDFPageCountError, PDFSyntaxError
+from PIL.Image import DecompressionBombError
 
 if "PY_ENV" in environ and environ["PY_ENV"] == "production":
     client = google.cloud.logging.Client()
@@ -167,8 +168,8 @@ def convert_pdf_to_jpg_bytes(pdf_as_bytes):
 
     try:
         images = convert_from_bytes(pdf_as_bytes, dpi)
-    except (TypeError, PDFInfoNotInstalledError, PDFPageCountError, PDFSyntaxError) as error:
         logging.error(error)
+    except (TypeError, PDFInfoNotInstalledError, PDFPageCountError, PDFSyntaxError, DecompressionBombError) as error:
         messages = error
 
     count = len(images)

--- a/row.py
+++ b/row.py
@@ -454,7 +454,10 @@ def upload_results(frame, bucket_name, out_name):
     bucket = storage_client.bucket(bucket_name)
     new_blob = bucket.blob(file_name)
 
-    new_blob.upload_from_string(frame.to_csv(), content_type="text/csv")
+    parquet = BytesIO()
+    frame.to_parquet(parquet, compression="gzip")
+
+    new_blob.upload_from_file(parquet, content_type="application/gzip")
 
 
 def format_time(seconds):

--- a/row_cli.py
+++ b/row_cli.py
@@ -10,17 +10,20 @@ Usage:
     row_cli.py image convert <file_name> (--save-to=location)
     row_cli.py detect circles <file_name> [--save-to=location]
     row_cli.py detect characters <file_name>
-    row_cli.py results write
+    row_cli.py results download <run_name> (--from=location)
+    row_cli.py results merge <run_name> (--from=location)
+    row_cli.py results summarize <run_name> (--from=location)
 
 Options:
     --from=location                 The bucket or directory to operate on
     --task-index=index              The index of the task running
     --instances=size                The number of containers running the job [default: 10]
-    --save-to=location    The location to output the stuff
+    --save-to=location              The location to output the stuff
 Examples:
     python row_cli.py storage generate-index --from=./test-data --save-to=./data
     python row_cli.py storage pick-range --from=.ephemeral --task-index=0 --instances=10 --file-count=100
     python row_cli.py image convert ./test-data/multiple_page.pdf --save-to=./test
+    python row_cli.py results download bobcat --from=bucket-name
 """
 
 import logging
@@ -122,6 +125,18 @@ def main():
             print("detecting circles in %s", item_path)
 
             return row.get_characters_from_image(row.convert_to_cv2_image(item_path.read_bytes()))
+
+    if args["results"]:
+        if args["download"]:
+            location = row.download_run(args["--from"], args["<run_name>"])
+
+            print(f"files downloaded to {location}")
+
+        if args["merge"]:
+            row.merge_run(args["--from"], args["<run_name>"])
+
+        if args["summarize"]:
+            row.summarize_run(args["--from"], args["<run_name>"])
 
 
 if __name__ == "__main__":

--- a/row_run.py
+++ b/row_run.py
@@ -56,7 +56,9 @@ def main():
 
         if extension == ".pdf":
             conversion_start = perf_counter()
-            images, count, messages = row.convert_pdf_to_jpg_bytes(bucket.blob(object_name).download_as_bytes())
+            images, count, messages = row.convert_pdf_to_jpg_bytes(
+                bucket.blob(object_name).download_as_bytes(), object_name
+            )
             logging.info("%s contained %i pages and converted with message %s", object_name, count, messages)
             logging.info(
                 "job %i: conversion time taken for object %s: %s",

--- a/row_run.py
+++ b/row_run.py
@@ -108,10 +108,10 @@ def main():
             "job %i: total time taken for entire task %s", TASK_INDEX, row.format_time(perf_counter() - object_start)
         )
 
-        result_dataframe = row.write_results(result_dataframe, object_name, all_results)
+        result_dataframe = row.append_results(result_dataframe, object_name, all_results)
 
     #: Upload results to GCP bucket as CSV file
-    row.upload_csv(result_dataframe, OUTPUT_BUCKET_NAME, f"ocr_results_{TASK_INDEX}.csv")
+    row.upload_results(result_dataframe, OUTPUT_BUCKET_NAME, f"ocr_results_{TASK_INDEX}.gzip")
 
     logging.info("job %i: time taken for entire job %s", TASK_INDEX, row.format_time(perf_counter() - job_start))
 

--- a/row_test.py
+++ b/row_test.py
@@ -15,7 +15,7 @@ root = Path(__file__).parent / "test-data"
 def test_convert_pdf_to_pil_single_page_pdf():
     pdf = root / "single_page.PDF"
 
-    images, count, _ = row.convert_pdf_to_jpg_bytes(pdf.read_bytes())
+    images, count, _ = row.convert_pdf_to_jpg_bytes(pdf.read_bytes(), "test_pdf")
 
     assert count == 1
     assert images is not None
@@ -24,7 +24,7 @@ def test_convert_pdf_to_pil_single_page_pdf():
 def test_convert_pdf_to_pil_multi_page_pdf():
     pdf = root / "multiple_page.pdf"
 
-    images, count, _ = row.convert_pdf_to_jpg_bytes(pdf.read_bytes())
+    images, count, _ = row.convert_pdf_to_jpg_bytes(pdf.read_bytes(), "test_pdf")
 
     assert count == 5
     assert images is not None
@@ -33,7 +33,7 @@ def test_convert_pdf_to_pil_multi_page_pdf():
 def test_convert_pdf_to_pil_handles_invalid_pdf():
     pdf = root / "invalid.pdf"
 
-    images, count, message = row.convert_pdf_to_jpg_bytes(pdf.read_bytes())
+    images, count, message = row.convert_pdf_to_jpg_bytes(pdf.read_bytes(), "test_pdf")
 
     assert count == 0
     assert images == []
@@ -41,7 +41,7 @@ def test_convert_pdf_to_pil_handles_invalid_pdf():
 
 
 def test_convert_pdf_to_pil_handles_empty_bytes():
-    images, count, message = row.convert_pdf_to_jpg_bytes(None)
+    images, count, message = row.convert_pdf_to_jpg_bytes(None, "test_pdf")
 
     assert count == 0
     assert images == []


### PR DESCRIPTION
Ok, so the CSV result data posed an issue. The arrays were encoded as strings in the CSV and I had to do some trickery to bring it back to an array. So I think it's better to use parquet. That preserves everything.

Here's the summary of bobcat

```
INFO    02-02 19:12:57        row:  542 summarizing bobcat
INFO    02-02 19:12:57        row:  551 total files processed: 9034, {'extractions': 8287, 'unmatchable': 6134, 'unrecognized characters': 1257}
```

So we got about 10% of the files processed on our first try. 

To break down some of the 5000 jobs

446 seem to be weird cloud run failures.
280 seem to be memory issues.
18 jobs had images too large for cv2 and considered an attack.

This is based on the logs and isn't adding up so who knows what really happened. I think we may need to slow down the parallelization. Maybe we DOS'd some things as the jobs seemed to just be broken.  I digress.

I refactored the upload to use parquet. We'll need to use my foolery if we want to make any use of the first run results but I'm happy to trash that and start fresh. 

The download works as you'd expect.

I added the merge and it works well enough.

I made a stub of a summarize but I think this could give us some actionable data beyond what is there now. We'll need to intersect the files that processed successfully with the file index to generate the next index until everything completes normally.

We'll want to run this on the subset index to make sure it's all good.