### PR TITLE
Feat/process ocr results

### DIFF
--- a/row.py
+++ b/row.py
@@ -922,6 +922,8 @@ def filter_ocr_results(original_results_file, out_dir):
     logging.info("saved filtered ocr results to %s", out_file)
 
     return out_dir
+
+
 def summarize_run(folder, run_name):
     """summarize the results of a run
 

--- a/row.py
+++ b/row.py
@@ -810,8 +810,6 @@ def download_ocr_results(bucket_name, run_name, out_dir):
     if bucket_name.startswith("gs://"):
         bucket_name = bucket_name[5:]
 
-    if "STORAGE_CLIENT" not in globals():
-        STORAGE_CLIENT = google.cloud.storage.Client()
     bucket = STORAGE_CLIENT.bucket(bucket_name)
     blobs = bucket.list_blobs(prefix=run_name)
     location = Path(__file__).parent / "data"

--- a/row.py
+++ b/row.py
@@ -814,10 +814,8 @@ def download_ocr_results(bucket_name, run_name, out_dir):
     blobs = bucket.list_blobs(prefix=run_name)
     location = Path(__file__).parent / "data"
 
-    if not location.joinpath(f"ocr_results/{run_name}").exists():
-        location.joinpath(f"ocr_results/{run_name}").mkdir(parents=True)
-
     ocr_dir = location.joinpath(f"ocr_results/{run_name}")
+    ocr_dir.mkdir(parents=True, exist_ok=True)
 
     #: download .gz files
     logging.info("downloading .gz files from cloud storage")
@@ -875,8 +873,6 @@ def filter_ocr_results(original_results_file, out_dir):
 
     out_dir = Path(out_dir)
 
-    if not out_dir.exists():
-        out_dir.mkdir(parents=True)
 
     results_df = pd.read_parquet(original_results_file)
 

--- a/row.py
+++ b/row.py
@@ -917,6 +917,7 @@ def filter_ocr_results(original_results_file, out_dir):
     #: Convert list column to string
     results_df["text"] = results_df.apply(lambda r: " ".join(r["text"]), axis=1)
 
+    #: Check number of rows before/after removing duplicates
     intermediate_length = len(results_df.index)
     logging.info("rumber of rows before de-duplicating: %i", intermediate_length)
     results_df.drop_duplicates(inplace=True, ignore_index=True)
@@ -926,6 +927,7 @@ def filter_ocr_results(original_results_file, out_dir):
     logging.info("rumber of rows after removing duplicates: %i", final_length)
     logging.info("removed %i duplicate rows", diff)
 
+    #: Save output locally
     out_file = out_dir / "filtered_ocr_results.csv"
     results_df.to_csv(out_file)
     logging.info("saved filtered ocr results to %s", out_file)

--- a/row.py
+++ b/row.py
@@ -853,14 +853,14 @@ def download_ocr_results(bucket_name, run_name, out_dir):
 
 
 def filter_ocr_results(original_results_file, out_dir):
-    """download ocr results from a GCP bucket
+    """filter ocr results down to quality results by filtering out irrelevant patterns
 
     Args:
-        original_results (str): path to the parquet file with original combined results (path_to_file.gz)
+        original_results_file (str): path to the parquet file with original combined results (path_to_file.gz)
         out_dir (str): where to save the CSV file results
 
     Returns:
-        str: the location of the output CSV file
+        str: the location of the output CSV file with filtered results
     """
     #: silence pandas SettingWithCopyWarning
     pd.options.mode.chained_assignment = None

--- a/row.py
+++ b/row.py
@@ -928,7 +928,7 @@ def filter_ocr_results(original_results_file, out_dir):
     logging.info("removed %i duplicate rows", diff)
 
     #: Save output locally
-    out_file = out_dir / "filtered_ocr_results.csv"
+    out_file = out_dir / f"filtered-ocr-results-{datetime.now().strftime('%Y-%m-%d-%H-%M')}.csv"
     results_df.to_csv(out_file)
     logging.info("saved filtered ocr results to %s", out_file)
 

--- a/row.py
+++ b/row.py
@@ -821,9 +821,7 @@ def download_ocr_results(bucket_name, run_name, out_dir):
     logging.info("downloading .gz files from cloud storage")
     [blob.download_to_filename(ocr_dir / blob.name) for blob in blobs if blob.name.endswith(".gz")]
 
-    iterator = ocr_dir.glob("*.gz")
-
-    ocr_files = [item for item in iterator if item.is_file()]
+    ocr_files = ocr_dir.glob("*.gz")
 
     logging.info("combining %i files into a single dataframe", len(ocr_files))
 

--- a/row.py
+++ b/row.py
@@ -819,10 +819,7 @@ def download_ocr_results(bucket_name, run_name, out_dir):
 
     #: download .gz files
     logging.info("downloading .gz files from cloud storage")
-    for blob in blobs:
-        if blob.name.endswith(".gz"):
-            print(blob.name)
-            blob.download_to_filename(ocr_dir / blob.name)
+    [blob.download_to_filename(ocr_dir / blob.name) for blob in blobs if blob.name.endswith(".gz")]
 
     iterator = ocr_dir.glob("*.gz")
 
@@ -852,8 +849,7 @@ def download_ocr_results(bucket_name, run_name, out_dir):
 
     #: delete downloaded files
     logging.info("deleting individual ocr files")
-    for ocr_file in ocr_files:
-        Path(ocr_file).unlink()
+    [Path(ocr_file).unlink() for ocr_file in ocr_files]
 
     return out_dir
 

--- a/row.py
+++ b/row.py
@@ -867,6 +867,7 @@ def filter_ocr_results(original_results_file, out_dir):
 
     out_dir = Path(out_dir)
 
+    out_dir.mkdir(parents=True, exist_ok=True)
 
     results_df = pd.read_parquet(original_results_file)
 

--- a/row_cli.py
+++ b/row_cli.py
@@ -14,6 +14,7 @@ Usage:
     row_cli.py detect circles <file_name> (--save-to=location) [--mosaic]
     row_cli.py results download <run_name> (--from=location)
     row_cli.py results summarize <run_name> (--from=location)
+    row_cli.py ocr-results download <run_name> (--from=location --save-to=location)
 
 Options:
     --from=location                 The bucket or directory to operate on
@@ -29,6 +30,7 @@ Examples:
     python row_cli.py process images --job=test --from=./test-data --save-to=./.ephemeral --index=./test-data --task-index=0 --file-count=1 --instances=1
     python row_cli.py process circles ---job=test --from=./test-data --save-to=./.ephemeral --index=./test-data --task-index=0 --file-count=1 --instances=1 --project=123456789 --processor=123456789
     python row_cli.py results download bobcat --from=bucket-name
+    python row_cli.py ocr-results download alligator --from=bucket-name --save-to=./data
 """
 
 import logging
@@ -163,6 +165,11 @@ def main():
 
     if args["results"] and args["summarize"]:
         row.summarize_run(args["--from"], args["<run_name>"])
+
+    if args["ocr-results"] and args["download"]:
+        location = row.download_ocr_results(args["--from"], args["<run_name>"], args["--save-to"])
+
+        print(f"files downloaded to {location}")
 
     if args["index"] and args["filter"]:
         index = Path(args["<file_name>"])

--- a/row_cli.py
+++ b/row_cli.py
@@ -15,6 +15,7 @@ Usage:
     row_cli.py results download <run_name> (--from=location)
     row_cli.py results summarize <run_name> (--from=location)
     row_cli.py ocr-results download <run_name> (--from=location --save-to=location)
+    row_cli.py ocr-results filter <file_name> (--save-to=location)
 
 Options:
     --from=location                 The bucket or directory to operate on
@@ -31,6 +32,7 @@ Examples:
     python row_cli.py process circles ---job=test --from=./test-data --save-to=./.ephemeral --index=./test-data --task-index=0 --file-count=1 --instances=1 --project=123456789 --processor=123456789
     python row_cli.py results download bobcat --from=bucket-name
     python row_cli.py ocr-results download alligator --from=bucket-name --save-to=./data
+    python row_cli.py ocr-results filter ./data/alligator/combined_ocr_results --save-to=./data
 """
 
 import logging
@@ -168,6 +170,11 @@ def main():
 
     if args["ocr-results"] and args["download"]:
         location = row.download_ocr_results(args["--from"], args["<run_name>"], args["--save-to"])
+
+        print(f"files downloaded to {location}")
+
+    if args["ocr-results"] and args["filter"]:
+        location = row.filter_ocr_results(args["<file_name>"], args["--save-to"])
 
         print(f"files downloaded to {location}")
 


### PR DESCRIPTION
This PR adds two new functions and CLI options.  The first one (`download_ocr_results`) downloads and combines the zipped parquet files into a single zipped parquet file using pandas and dataframe concatenation.  It also deduplicates rows and deletes the original files, leaving only the combined file in local storage.  The second one (`filter_ocr_results`) does some initial filtering of the data to remove extra spaces, newlines, and special characters and save the data locally.  Entries that are completely alphabetical or start with a letter are removed.  It also calculates the original UDOT filename in a new column (ex: 'archive1/001-4_01_Plan_Rev-1.TIF').  This isn't a finished product, but the initial results seem pretty good.

- Some numbers (not sure why I seem to have more OCR rows than valid mosaics):
  - Total files: 89,537
  - Number of valid mosaic files: 52,106
  - Number of rows in combined OCR results: 52,184
  - Number of rows in initial filtered OCR results: 39,938
